### PR TITLE
 SiparisKontrolListesiV2 metodu eklendi

### DIFF
--- a/examples/siparis_kontrol_listesi.php
+++ b/examples/siparis_kontrol_listesi.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Epttavm\ApiClient;
+use Epttavm\Exception\EpaException;
+
+try {
+    $a = ApiClient::init('https://exact.service.url/service?wsdl', 'username', 'password', ['debug'=>false]);
+    
+    $date1 = new DateTime('2018-01-01 00:00:00');
+    $date2 = new DateTime(); // now()
+    $result = $a->SiparisKontrolListesiV2($date1, $date2, 0);
+    
+    print_r($result);
+
+} catch (EpaException $e) {
+	echo "HATA OLDU:\n".$e->getMessage();
+}

--- a/src/Epttavm/ApiClient.php
+++ b/src/Epttavm/ApiClient.php
@@ -129,11 +129,11 @@ class ApiClient
 		$params->AktifSiparisler = $aktifSiparisler;
 		$res = $this->__call('SiparisKontrolListesiV2',[$params]);
 
-			if ($this->debug)
-			{
-				echo "REQUEST:\n".$this->client->__getLastRequest()."\n";
-				echo "REQUEST HEADERS:\n".$this->client->__getLastRequestHeaders()."\n";
-				echo "RESPONSE:\n".$this->client->__getLastResponse()."\n";
+		if ($this->debug)
+		{
+			echo "REQUEST:\n".$this->client->__getLastRequest()."\n";
+			echo "REQUEST HEADERS:\n".$this->client->__getLastRequestHeaders()."\n";
+			echo "RESPONSE:\n".$this->client->__getLastResponse()."\n";
 		}
 
 		if($res && isset($res->SiparisKontrolListesiV2Result))

--- a/src/Epttavm/ApiClient.php
+++ b/src/Epttavm/ApiClient.php
@@ -112,5 +112,34 @@ class ApiClient
 			$res = $res->StokGuncelleResult;
 		return $res;
 	}
+	
+	/**
+	 * @param DateTime $baslangicTarihi
+	 * @param DateTime $bitisTarihi
+	 * @param int $aktifSiparisler
+	 *
+	 * @return mixed
+	 * @throws EpaException
+	 */
+    	public function SiparisKontrolListesiV2(DateTime $baslangicTarihi, DateTime $bitisTarihi, $aktifSiparisler = 0)
+	{
+		$params = new \stdClass();
+		$params->BaslangicTarihi = $baslangicTarihi->format(DateTime::RFC3339);
+		$params->BitisTarihi = $bitisTarihi->format(DateTime::RFC3339);
+		$params->AktifSiparisler = $aktifSiparisler;
+		$res = $this->__call('SiparisKontrolListesiV2',[$params]);
+
+			if ($this->debug)
+			{
+				echo "REQUEST:\n".$this->client->__getLastRequest()."\n";
+				echo "REQUEST HEADERS:\n".$this->client->__getLastRequestHeaders()."\n";
+				echo "RESPONSE:\n".$this->client->__getLastResponse()."\n";
+		}
+
+		if($res && isset($res->SiparisKontrolListesiV2Result))
+			$res = $res->SiparisKontrolListesiV2Result;
+		
+		return $res;
+	}
 
 }


### PR DESCRIPTION
ePttAVM tarafından gönderilen v2.3.2 dökümanında SiparisKontrolListesiV2 metodu için aşağıdaki parametlerin alındığı yazıyor;

TarihiBas : (DateTime) Liste Başlangıç Tarihi 
TarihiBitis : (DateTime) Liste Bitiş Tarihi 
AktifSiparisler :(int)

Ancak parametreler aşağıdaki gibi olmalı;

BaslangicTarihi : (DateTime) Liste Başlangıç Tarihi 
BitisTarihi : (DateTime) Liste Bitiş Tarihi 
AktifSiparisler :(int)

Ayrıca SiparisKontrolListesiV2 metodu ApiClient sınıfına eklendi ve ilgili fonksiyon için örnek siparis_kontrol_listesi.php dosyasına eklendi.